### PR TITLE
Add mesopelagique/formatter-UrlInApp

### DIFF
--- a/formatter.txt
+++ b/formatter.txt
@@ -10,3 +10,4 @@ https://github.com/4d-go-mobile/formatter-TextToImage
 https://github.com/4d-go-mobile/formatter-TextToString
 https://github.com/4d-go-mobile/formatter-Url
 https://github.com/4d-go-mobile/formatter-DownloadActivity
+https://github.com/mesopelagique/formatter-UrlInApp


### PR DESCRIPTION
Hi,

https://github.com/mesopelagique/formatter-UrlInApp

A new format to open in internal web view ie. safari controller for iOS instead of opening in external web browser for `url` format

I have launched the github ci check
[![check](https://github.com/mesopelagique/formatter-UrlInApp/actions/workflows/check.yml/badge.svg)](https://github.com/mesopelagique/formatter-UrlInApp/actions/workflows/check.yml)

I have made a release with attached zip (with github ci)
[![Upload artifact](https://github.com/mesopelagique/formatter-UrlInApp/actions/workflows/release.yml/badge.svg)](https://github.com/mesopelagique/formatter-UrlInApp/actions/workflows/release.yml)
[![release](https://img.shields.io/github/v/release/mesopelagique/formatter-UrlInApp)](https://github.com/mesopelagique/formatter-UrlInApp/releases/latest)

PS: I have made also a little dev doc to make new one [here](https://github.com/4d-go-mobile/sdk/blob/master/docs/formatter_bindind_code.md) 
